### PR TITLE
V0.1.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,12 +37,17 @@ Differentiable and GPU-enabled fast wavelet transforms in JAX.
 Features
 """"""""
 - 1d analysis and synthesis transforms are implemented in ``src/jaxwt/conv_fwt.py``.
-- 2d analysis and synthesis transform are part of the ``src/jaxwt/conv_fwt_2d.py`` module.
+  Try ``wavedec`` and ``waverec``.
+- 2d analysis and synthesis transforms are part of the ``src/jaxwt/conv_fwt_2d.py`` module.
+  The two functions are called ``wavedec2`` and ``waverec2``.
+- Furthermore, 3d transforms are provided by the ``wavedec3`` and ``waverec3`` functions.
 - ``cwt``-function supports 1d continuous wavelet transforms.
 - The ``WaveletPacket`` object supports 1d wavelet packet transforms.
 - ``WaveletPacket2d`` implements two-dimensional wavelet packet transforms.
+- ``swt`` computes a single dimensional stationary transform ``iswt`` inverts it. 
 
-This toolbox extends `PyWavelets <https://pywavelets.readthedocs.io/en/latest/>`_ . We additionally provide GPU and gradient support via a Jax backend.
+This toolbox extends `PyWavelets <https://pywavelets.readthedocs.io/en/latest/>`_ .
+``jaxwt`` additionally provides GPU and gradient support via a Jax backend.
 
 Installation
 """"""""""""
@@ -51,7 +56,7 @@ Afterward, type ``pip install jaxwt`` to install the Jax-Wavelet-Toolbox. You ca
 
 Documentation
 """""""""""""
-The documentation is available at: https://jax-wavelet-toolbox.readthedocs.io .
+The documentation is available at: https://jax-wavelet-toolbox.readthedocs.io/en/latest/jaxwt.html .
 
 
 Transform Examples:

--- a/docs/jaxwt.rst
+++ b/docs/jaxwt.rst
@@ -17,6 +17,14 @@ jaxwt.conv\_fwt\_2d module
    :undoc-members:
    :show-inheritance:
 
+jaxwt.conv\_fwt\_3d module
+--------------------------
+
+.. automodule:: jaxwt.conv_fwt_3d
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 jaxwt.continuous\_transform
 ---------------------------
 
@@ -33,10 +41,9 @@ jaxwt.packets module
    :undoc-members:
    :show-inheritance:
 
-jaxwt.utils module
-------------------
+jaxwt.stationary_transform
 
-.. automodule:: jaxwt.utils
+.. automodule:: jaxwt.stationary_transform
    :members:
    :undoc-members:
    :show-inheritance:

--- a/src/jaxwt/__init__.py
+++ b/src/jaxwt/__init__.py
@@ -4,4 +4,5 @@
 from .continuous_transform import cwt
 from .conv_fwt import wavedec, waverec
 from .conv_fwt_2d import wavedec2, waverec2
+from .conv_fwt_3d import wavedec3, waverec3
 from .packets import WaveletPacket, WaveletPacket2D

--- a/src/jaxwt/__init__.py
+++ b/src/jaxwt/__init__.py
@@ -6,3 +6,4 @@ from .conv_fwt import wavedec, waverec
 from .conv_fwt_2d import wavedec2, waverec2
 from .conv_fwt_3d import wavedec3, waverec3
 from .packets import WaveletPacket, WaveletPacket2D
+from .stationary_transform import iswt, swt

--- a/src/jaxwt/_stationary_transform.py
+++ b/src/jaxwt/_stationary_transform.py
@@ -1,0 +1,117 @@
+"""Code for stationary wavelet transforms."""
+from typing import List, Optional, Union
+
+import jax
+import jax.numpy as jnp
+import pywt
+
+from .conv_fwt import (
+    _get_filter_arrays,  # _fwt_unpad,
+    _postprocess_array_dec1d,
+    _preprocess_array_dec1d,
+)
+from .utils import _as_wavelet, _fold_axes, _unfold_axes
+
+
+def _swt(
+    data: jnp.ndarray,
+    wavelet: Union[pywt.Wavelet, str],
+    level: Optional[int] = None,
+    precision: str = "highest",
+) -> List[jnp.ndarray]:
+    """Compute a multilevel 1d stationary wavelet transform.
+
+    Args:
+        data (torch.Tensor): The input data of shape [batch_size, time].
+        wavelet (Union[Wavelet, str]): The wavelet to use.
+        level (Optional[int], optional): The number of levels to compute
+
+    Returns:
+        List[torch.Tensor]: Same as wavedec.
+        Equivalent to pywt.swt with trim_approx=True.
+    """
+    wavelet = _as_wavelet(wavelet)
+    data, ds = _preprocess_array_dec1d(data)
+
+    dec_lo, dec_hi, _, _ = _get_filter_arrays(wavelet, flip=True, dtype=data.dtype)
+    filt_len = dec_lo.shape[-1]
+    filt = jnp.stack([dec_lo, dec_hi], 0)
+
+    if level is None:
+        level = pywt.swt_max_level(data.shape[-1])
+
+    result_list = []
+    res_lo = data
+    for current_level in range(level):
+        dilation = 2**current_level
+        padl, padr = dilation * (filt_len // 2 - 1), dilation * (filt_len // 2)
+        res_lo = jnp.pad(
+            res_lo, [(0, 0)] * (data.ndim - 1) + [(padl, padr)], mode="wrap"
+        )
+        res = jax.lax.conv_general_dilated(
+            lhs=res_lo,  # lhs = NCH image tensor
+            rhs=filt,  # rhs = OIH conv kernel tensor
+            padding=[(0, 0)],
+            window_strides=[1],
+            rhs_dilation=[dilation],
+            dimension_numbers=("NCT", "OIT", "NCT"),
+            precision=jax.lax.Precision(precision),
+        )
+        res_lo, res_hi = jnp.split(res, 2, 1)
+        # Trim_approx == False
+        # result_list.append((res_lo.squeeze(1), res_hi.squeeze(1)))
+        result_list.append(res_hi.squeeze(1))
+    result_list.append(res_lo.squeeze(1))
+
+    if ds:
+        result_list = _postprocess_array_dec1d(result_list, ds)
+
+    return result_list[::-1]
+
+
+def _iswt(
+    coeffs: List[jnp.ndarray],
+    wavelet: pywt.Wavelet,
+    precision: str = "highest",
+) -> jnp.ndarray:
+    ds = None
+    if coeffs[0].ndim > 2:
+        fold_coeffs = []
+        ds = list(coeffs[0].shape)
+        for uf_coeff in coeffs:
+            f_coeff, _ = _fold_axes(uf_coeff, 1)
+            fold_coeffs.append(f_coeff)
+        coeffs = fold_coeffs
+
+    wavelet = _as_wavelet(wavelet)
+    # unlike pytorch lax's transpose conv requires filter flips.
+    _, _, rec_lo, rec_hi = _get_filter_arrays(wavelet, flip=True, dtype=coeffs[0].dtype)
+    filt_len = rec_lo.shape[-1]
+    filt = jnp.stack([rec_lo, rec_hi], 1)
+
+    res_lo = coeffs[0]
+    for c_pos, res_hi in enumerate(coeffs[1:]):
+        dilation = 2 ** (len(coeffs[1:]) // 2 - c_pos)
+        padl, padr = dilation * (filt_len // 2), dilation * (filt_len // 2 - 1)
+        res_lo = jnp.stack([res_lo, res_hi], 1)
+        res_lo = jnp.pad(
+            res_lo, [(0, 0)] * (res_lo.ndim - 1) + [(padl, padr)], mode="wrap"
+        )
+        res_lo = res_lo[..., ::2]
+        res_lo = jax.lax.conv_general_dilated(
+            lhs=res_lo,
+            rhs=filt,
+            padding=[(0, 0)],
+            lhs_dilation=[2],
+            rhs_dilation=[dilation],
+            window_strides=[1],
+            dimension_numbers=("NCH", "OIH", "NCH"),
+            precision=jax.lax.Precision(precision),
+        )
+        # res_lo = _fwt_unpad(res_lo, filt_len, c_pos, coeffs)
+        # res_lo = res_lo[..., ::2]
+        res_lo = res_lo.squeeze(1)
+
+    if ds:
+        res_lo = _unfold_axes(res_lo, ds, 1)
+    return res_lo

--- a/src/jaxwt/continuous_transform.py
+++ b/src/jaxwt/continuous_transform.py
@@ -24,13 +24,13 @@ def cwt(
     wavelet: Union[ContinuousWavelet, str],
     sampling_period: float = 1.0,
 ) -> Tuple[jnp.ndarray, jnp.ndarray]:
-    """Compute the single dimensional continuous wavelet transform.
+    """Compute the single-dimensional continuous wavelet transform.
 
     This function is a jax port of pywt.cwt as found at:
     https://github.com/PyWavelets/pywt/blob/master/pywt/_cwt.py
 
     Args:
-        data (jnp.ndarray): The ijnput tensor of shape [batch_size, time].
+        data (jnp.ndarray): The input tensor of shape [batch_size, time].
         scales (np.ndarray or jnp.array):
             The wavelet scales to use. One can use
             ``f = pywt.scale2frequency(wavelet, scale)/sampling_period`` to determine

--- a/src/jaxwt/conv_fwt.py
+++ b/src/jaxwt/conv_fwt.py
@@ -15,7 +15,9 @@ import pywt
 from .utils import _as_wavelet, _fold_axes, _unfold_axes
 
 
-def _preprocess_array_dec1d(data: jnp.ndarray) -> Tuple[jnp.ndarray, List[int]]:
+def _preprocess_array_dec1d(
+        data: jnp.ndarray
+        ) -> Tuple[jnp.ndarray, Union[List[int], None]]:
     ds = None
     if len(data.shape) == 1:
         # add channel and batch dimension.
@@ -29,7 +31,8 @@ def _preprocess_array_dec1d(data: jnp.ndarray) -> Tuple[jnp.ndarray, List[int]]:
     return data, ds
 
 
-def _postprocess_array_dec1d(result_lst, ds):
+def _postprocess_array_dec1d(
+        result_lst: List[jnp.ndarray], ds: List[int]) -> List[jnp.ndarray]:
     unfold_list = []
     for fres in result_lst:
         unfold_list.append(_unfold_axes(fres, ds, 1))

--- a/src/jaxwt/conv_fwt.py
+++ b/src/jaxwt/conv_fwt.py
@@ -25,14 +25,15 @@ def wavedec(
     """Compute the analysis wavelet transform of the last dimension.
 
     Args:
-        data (jnp.ndarray): Input data array of shape [batch, time].
+        data (jnp.ndarray): Input data array.
+            I.e. of shape [batch, time].
         wavelet (pywt.Wavelet): The named tuple containing the wavelet
                     filter arrays.
         level (int): Max scale level to be used,
                      of none as many levels as possible are
                      used. Defaults to None.
         mode (str): The padding used to extend the input signal. Choose reflect, symmetric or zero.
-            Defaults to reflect.
+            Defaults to symmetric.
         precision (str): The desired precision, choose "fastest", "high" or "highest".
             Defaults to "highest".
 
@@ -127,7 +128,7 @@ def waverec(
         >>> jwt.waverec(transformed, pywt.Wavelet('haar'))
     """
     fold = False
-    if coeffs[0].ndim > 3:
+    if coeffs[0].ndim > 2:
         fold = True
         fold_coeffs = []
         ds = list(coeffs[0].shape)

--- a/src/jaxwt/conv_fwt.py
+++ b/src/jaxwt/conv_fwt.py
@@ -5,22 +5,14 @@
 # Created on Thu Jun 11 2020
 # Copyright (c) 2020 Moritz Wolter
 #
-from typing import Any, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import jax
 import jax.lax
 import jax.numpy as jnp
 import pywt
 
-from .utils import _as_wavelet, _fold_axes, _unfold_axes
-
-
-def _check_if_array(array: Any) -> jnp.ndarray:
-    if not isinstance(array, jnp.ndarray):
-        raise ValueError(
-            "First element of coeffs must be the approximation coefficient tensor."
-        )
-    return array
+from .utils import _as_wavelet, _check_if_array, _fold_axes, _unfold_axes
 
 
 def _preprocess_array_dec1d(

--- a/src/jaxwt/conv_fwt.py
+++ b/src/jaxwt/conv_fwt.py
@@ -73,7 +73,7 @@ def wavedec(
                      as possible are used. Defaults to None.
         axis (int): Compute the transform over this axis instead of the
             last one. Defaults to -1.
-        precision (str): The desired precision, choose "fastest", "high" or "highest".
+        precision (str): For desired precision, choose "fastest", "high" or "highest".
             Defaults to "highest".
 
 
@@ -98,7 +98,7 @@ def wavedec(
         if isinstance(axis, int):
             data = data.swapaxes(axis, -1)
         else:
-            raise ValueError("wavedec transforms a single axis.")
+            raise ValueError("wavedec transforms a single axis only.")
 
     wavelet = _as_wavelet(wavelet)
     data, ds = _preprocess_array_dec1d(data)
@@ -181,7 +181,7 @@ def waverec(
                 swap.append(coeff.swapaxes(axis, -1))
             coeffs = swap
         else:
-            raise ValueError("wavedec transforms a single axis.")
+            raise ValueError("waverec transforms a single axis only.")
 
     ds = None
     if coeffs[0].ndim > 2:

--- a/src/jaxwt/conv_fwt.py
+++ b/src/jaxwt/conv_fwt.py
@@ -54,8 +54,8 @@ def _preprocess_result_list_rec1d(
 def wavedec(
     data: jnp.ndarray,
     wavelet: Union[pywt.Wavelet, str],
-    level: Optional[int] = None,
     mode: str = "symmetric",
+    level: Optional[int] = None,
     axis: int = -1,
     precision: str = "highest",
 ) -> List[jnp.ndarray]:
@@ -66,11 +66,13 @@ def wavedec(
             I.e. of shape [batch, time].
         wavelet (pywt.Wavelet): A wavelet name-string or a wavelet object
             containing the wavelet filter arrays.
-        level (int): Max scale level to be used, of none as many levels
-                     as possible are used. Defaults to None.
         mode (str): The padding used to extend the input signal.
             Choose reflect, symmetric or zero.
             Defaults to symmetric.
+        level (int): Max scale level to be used, of none as many levels
+                     as possible are used. Defaults to None.
+        axis (int): Compute the transform over this axis instead of the
+            last one. Defaults to -1.
         precision (str): The desired precision, choose "fastest", "high" or "highest".
             Defaults to "highest".
 
@@ -153,6 +155,7 @@ def waverec(
         wavelet (pywt.Wavelet): A string with a wavelet name or
             a wavelet object containing the wavelet filters used to evaluate
             the decomposition.
+        axis (int): Transform this axis instead of the last one. Defaults to -1.
         precision (str): The desired precision, choose "fastest", "high" or "highest".
             Defaults to "highest".
 

--- a/src/jaxwt/conv_fwt.py
+++ b/src/jaxwt/conv_fwt.py
@@ -5,7 +5,7 @@
 # Created on Thu Jun 11 2020
 # Copyright (c) 2020 Moritz Wolter
 #
-from typing import List, Optional, Tuple, Union, Any
+from typing import Any, List, Optional, Tuple, Union
 
 import jax
 import jax.lax
@@ -13,7 +13,6 @@ import jax.numpy as jnp
 import pywt
 
 from .utils import _as_wavelet, _fold_axes, _unfold_axes
-
 
 
 def _check_if_array(array: Any) -> jnp.ndarray:
@@ -48,9 +47,10 @@ def _postprocess_result_list_dec1d(
         unfold_list.append(_unfold_axes(fres, ds, 1))
     return unfold_list
 
+
 def _preprocess_result_list_rec1d(
-        result_lst: List[jnp.ndarray]
-    ) -> Tuple[List[jnp.ndarray], List[int]]:
+    result_lst: List[jnp.ndarray],
+) -> Tuple[List[jnp.ndarray], List[int]]:
     fold_coeffs = []
     ds = list(_check_if_array(result_lst[0]).shape)
     for uf_coeff in result_lst:

--- a/src/jaxwt/conv_fwt.py
+++ b/src/jaxwt/conv_fwt.py
@@ -66,6 +66,7 @@ def wavedec(
             I.e. of shape [batch, time].
         wavelet (pywt.Wavelet): A wavelet name-string or a wavelet object
             containing the wavelet filter arrays.
+            Check pywt.wavelist() for a list of options.
         mode (str): The padding used to extend the input signal.
             Choose reflect, symmetric or zero.
             Defaults to symmetric.
@@ -150,9 +151,10 @@ def waverec(
     """Reconstruct the original signal in one dimension.
 
     Args:
-        coeffs (list): Wavelet coefficients, typically produced by the wavedec function.
+        coeffs (List[jnp.ndarray]): Wavelet coefficients, typically produced
+            by the ``wavedec`` function.
             List entries of shape [batch_size, coefficients] work.
-        wavelet (pywt.Wavelet): A string with a wavelet name or
+        wavelet (Union[pywt.Wavelet, str]): A string with a wavelet name or
             a wavelet object containing the wavelet filters used to evaluate
             the decomposition.
         axis (int): Transform this axis instead of the last one. Defaults to -1.

--- a/src/jaxwt/conv_fwt_2d.py
+++ b/src/jaxwt/conv_fwt_2d.py
@@ -100,7 +100,6 @@ def wavedec2(
     if fold:
         unfold_list: List[Union[jnp.ndarray, Tuple[jnp.ndarray, ...]]] = []
         for fres in result_lst:
-            # TODO: Tuples, unterstuetzen!
             if isinstance(fres, jnp.ndarray):
                 unfold_list.append(_unfold_axes(fres, ds, 2))
             else:
@@ -146,7 +145,6 @@ def waverec2(
         >>> face = face.astype(jnp.float64)
         >>> transformed = jwt.wavedec2(face, pywt.Wavelet("haar"))
         >>> jwt.waverec2(transformed, pywt.Wavelet("haar"))
-
 
     """
     wavelet = _as_wavelet(wavelet)

--- a/src/jaxwt/conv_fwt_2d.py
+++ b/src/jaxwt/conv_fwt_2d.py
@@ -75,7 +75,7 @@ def wavedec2(
         wavelet (pywt.Wavelet): A namedtouple containing the filters for the transformation.
         level (int): The max level to be used, if not set as many levels as possible
                                will be used. Defaults to None.
-        mode (str): The desired padding mode. Choose reflect, symmetric or zero.
+        mode (str): The desired padding mode. Choose "reflect", "symmetric" or "zero".
             Defaults to symmetric.
         precision (str): The desired precision, choose "fastest", "high" or "highest".
             Defaults to "highest".
@@ -100,13 +100,9 @@ def wavedec2(
     dec_lo, dec_hi, _, _ = _get_filter_arrays(wavelet, flip=True, dtype=data.dtype)
     dec_filt = _construct_2d_filt(lo=dec_lo, hi=dec_hi)
 
-    if mode == "zero":
-        # translate pywt to numpy.
-        mode = "constant"
-
     if level is None:
         level = pywt.dwtn_max_level(
-            [data.shape[-1], data.shape[-2]], pywt.Wavelet("MyWavelet", wavelet)
+            [data.shape[-1], data.shape[-2]], wavelet
         )
 
     result_list: List[
@@ -258,6 +254,10 @@ def _fwt_pad2d(
         padr += 1
     if data.shape[-2] % 2 != 0:
         padb += 1
+
+    if mode == "zero":
+        # translate pywt to numpy.
+        mode = "constant"
 
     data = jnp.pad(data, ((0, 0), (0, 0), (padt, padb), (padl, padr)), mode)
     return data

--- a/src/jaxwt/conv_fwt_2d.py
+++ b/src/jaxwt/conv_fwt_2d.py
@@ -41,25 +41,26 @@ def _preprocess_array_dec2d(
 
 def wavedec2(
     data: jnp.ndarray,
-    wavelet: pywt.Wavelet,
+    wavelet: Union[pywt.Wavelet, str],
     mode: str = "symmetric",
     level: Optional[int] = None,
     axes: Tuple[int, int] = (-2, -1),
     precision: str = "highest",
 ) -> List[Union[jnp.ndarray, Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]]]:
-    """Compute the two dimensional wavelet analysis transform on the last two dimensions of the input data array.
+    """Compute the two-dimensional wavelet analysis transform on the last two dimensions of the input data array.
 
     Args:
         data (jnp.ndarray): Jax array containing the data to be transformed.
-            A possible input shape would be [batch size, hight, width].
-        wavelet (pywt.Wavelet): A namedtouple containing the filters for the transformation.
+            A possible input shape would be [batch size, height, width].
+        wavelet (Union[pywt.Wavelet, str]):  A wavelet object or wavelet string
+            for the transformation. Check pywt.wavelist() for a list of options.
         mode (str): The desired padding mode. Choose "reflect", "symmetric" or "zero".
             Defaults to symmetric.
         level (int): The max level to be used, if not set as many levels as possible
                                will be used. Defaults to None.
         axes (Tuple[int, int]): Compute the transform over these axes instead of the
             last two. Defaults to (-2, -1).
-        precision (str): The desired precision, choose "fastest", "high" or "highest".
+        precision (str): For the desired precision, choose "fastest", "high" or "highest".
             Defaults to "highest".
 
     Returns:
@@ -70,7 +71,7 @@ def wavedec2(
             and D diagonal coefficients.
 
     Raises:
-        ValueError: If axes does not have two elements or contains a repetition.
+        ValueError: If the axes tuple does not have two elements or contains a repetition.
 
     Examples:
         >>> import pywt, scipy.datasets
@@ -127,27 +128,28 @@ def wavedec2(
 
 def waverec2(
     coeffs: List[Union[jnp.ndarray, Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]]],
-    wavelet: pywt.Wavelet,
+    wavelet: Union[pywt.Wavelet, str],
     axes: Tuple[int, int] = (-2, -1),
     precision: str = "highest",
 ) -> jnp.ndarray:
-    """Compute a two dimensional synthesis wavelet transfrom.
+    """Compute a two-dimensional synthesis wavelet transform.
 
        Use it to reconstruct the original input image from the wavelet coefficients.
 
     Args:
         coeffs (list): The input coefficients, typically the output of wavedec2.
-        wavelet (pywt.Wavelet): The named tuple contining the filters used to compute the analysis transform.
+        wavelet (Union[pywt.Wavelet, str]): The wavelet to use for the synthesis transform.
         axes (Tuple[int, int]): Compute the transform over these axes instead of the
             last two. Defaults to (-2, -1).
-        precision (str): The desired precision, choose "fastest", "high" or "highest".
+        precision (str): For desired precision, choose "fastest", "high" or "highest".
             Defaults to "highest".
 
     Raises:
-        ValueError: If axes does not have two elements or contains a repetition.
+        ValueError: If the axes tuple does not have two elements or contains a repetition.
 
     Returns:
-        jnp.array: Reconstruction of the original input data array of shape [batch, height, width].
+        jnp.ndarray: Reconstruction of the original input data array
+          of shape [batch, height, width].
 
     Example:
         >>> import pywt, scipy.datasets

--- a/src/jaxwt/conv_fwt_2d.py
+++ b/src/jaxwt/conv_fwt_2d.py
@@ -9,7 +9,7 @@ import jax
 import jax.numpy as jnp
 import pywt
 
-from .conv_fwt import _get_filter_arrays, _check_if_array
+from .conv_fwt import _check_if_array, _get_filter_arrays
 from .utils import _as_wavelet, _fold_axes, _unfold_axes
 
 
@@ -109,7 +109,6 @@ def wavedec2(
         result_lst = unfold_list  # type: ignore
 
     return result_lst
-
 
 
 def waverec2(

--- a/src/jaxwt/conv_fwt_2d.py
+++ b/src/jaxwt/conv_fwt_2d.py
@@ -9,7 +9,7 @@ import jax
 import jax.numpy as jnp
 import pywt
 
-from .conv_fwt import _get_filter_arrays
+from .conv_fwt import _get_filter_arrays, _check_if_array
 from .utils import _as_wavelet, _fold_axes, _unfold_axes
 
 
@@ -110,13 +110,6 @@ def wavedec2(
 
     return result_lst
 
-
-def _check_if_array(array: Any) -> jnp.ndarray:
-    if not isinstance(array, jnp.ndarray):
-        raise ValueError(
-            "First element of coeffs must be the approximation coefficient tensor."
-        )
-    return array
 
 
 def waverec2(

--- a/src/jaxwt/conv_fwt_2d.py
+++ b/src/jaxwt/conv_fwt_2d.py
@@ -3,7 +3,7 @@
 # Created on Thu Jun 12 2020
 # Copyright (c) 2020 Moritz Wolter
 #
-from typing import Any, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import jax
 import jax.numpy as jnp

--- a/src/jaxwt/conv_fwt_2d.py
+++ b/src/jaxwt/conv_fwt_2d.py
@@ -239,7 +239,9 @@ def _construct_2d_filt(lo: jnp.ndarray, hi: jnp.ndarray) -> jnp.ndarray:
     return filt
 
 
-def _fwt_pad2d(data: jnp.ndarray, filt_len: int, mode: str = "reflect") -> jnp.ndarray:
+def _fwt_pad2d(
+    data: jnp.ndarray, filt_len: int, mode: str = "symmetric"
+) -> jnp.ndarray:
     padr = 0
     padl = 0
     padt = 0

--- a/src/jaxwt/conv_fwt_3d.py
+++ b/src/jaxwt/conv_fwt_3d.py
@@ -59,6 +59,10 @@ def wavedec3(
     fold = False
     wavelet = _as_wavelet(wavelet)
 
+    if mode == "zero":
+        # translate pywt to numpy.
+        mode = "constant"
+
     if len(data.shape) == 3:
         data = jnp.expand_dims(data, 1)
     elif len(data.shape) >= 4:
@@ -301,6 +305,10 @@ def _fwt_pad3d(
         padb += 1
     if data.shape[-3] % 2 != 0:
         padba += 1
+
+    if mode == "zero":
+        # translate pywt to numpy.
+        mode = "constant"
 
     data = jnp.pad(
         data, ((0, 0), (0, 0), (padfr, padba), (padt, padb), (padl, padr)), mode

--- a/src/jaxwt/conv_fwt_3d.py
+++ b/src/jaxwt/conv_fwt_3d.py
@@ -1,4 +1,8 @@
 """Three dimensional transformation support."""
+#
+# Created on Fri Aug 4 2023
+# Copyright (c) 2023 Moritz Wolter
+#
 
 from typing import Dict, List, Optional, Union
 
@@ -253,11 +257,11 @@ def _construct_3d_filt(lo: jnp.ndarray, hi: jnp.ndarray) -> jnp.ndarray:
     """Construct three-dimensional filters using outer products.
 
     Args:
-        lo (torch.Tensor): Low-pass input filter.
-        hi (torch.Tensor): High-pass input filter
+        lo (jnp.ndarray): Low-pass input filter.
+        hi (jnp.ndarray): High-pass input filter
 
     Returns:
-        torch.Tensor: Stacked 3d filters of dimension::
+        jnp.ndarray: Stacked 3d filters of dimension::
 
         [8, 1, length, height, width].
 

--- a/src/jaxwt/conv_fwt_3d.py
+++ b/src/jaxwt/conv_fwt_3d.py
@@ -1,0 +1,315 @@
+from typing import Dict, List, Optional, Tuple, Union
+
+import jax
+import jax.numpy as jnp
+import pywt
+
+from .conv_fwt import _check_if_array, _get_filter_arrays
+from .utils import _as_wavelet, _fold_axes, _unfold_axes
+
+
+def wavedec3(
+    data: jnp.ndarray,
+    wavelet: pywt.Wavelet,
+    level: Optional[int] = None,
+    mode: str = "symmetric",
+    precision: str = "highest",
+) -> List[Union[jnp.ndarray, Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]]]:
+    """Compute the three dimensional wavelet analysis transform on the last three \
+       dimensions of the input data array.
+
+    Args:
+        data (jnp.ndarray): Jax array containing the data to be transformed.
+            A possible input shape would be [batch size, channels, hight, width].
+        wavelet (pywt.Wavelet): A namedtouple containing the filters for the transformation.
+        level (int): The max level to be used, if not set as many levels as possible
+                               will be used. Defaults to None.
+        mode (str): The desired padding mode. Choose reflect, symmetric or zero.
+            Defaults to symmetric.
+        precision (str): The desired precision, choose "fastest", "high" or "highest".
+            Defaults to "highest".
+
+    Returns:
+        list: A list with the lll coefficients and dictionaries
+        with the filter order strings::
+
+            ("aad", "ada", "add", "daa", "dad", "dda", "ddd")
+
+        as keys. With a for the low pass or approximation filter and
+        d for the high-pass or detail filter.
+
+
+    Examples:
+        >>> import pywt
+        >>> import jaxwt as jwt
+        >>> import jax
+        >>> data = jax.random.uniform(jax.random.PRNGKey(42),
+                                      [3, 16, 16, 16])
+        >>> jwt.wavedec3(data, "haar", level=2)
+    """
+    fold = False
+    wavelet = _as_wavelet(wavelet)
+
+    if len(data.shape) == 3:
+        data = jnp.expand_dims(data, 1)
+    elif len(data.shape) >= 4:
+        fold = True
+        data, ds = _fold_axes(data, 3)
+        data = jnp.expand_dims(data, 1)
+    else:
+        raise ValueError(
+            "Wavedec3 needs at least  \
+                         three input dimensions to work."
+        )
+
+    dec_lo, dec_hi, _, _ = _get_filter_arrays(wavelet, flip=True, dtype=data.dtype)
+    dec_filt = _construct_3d_filt(lo=dec_lo, hi=dec_hi)
+
+    if mode == "zero":
+        # translate pywt to numpy.
+        mode = "constant"
+
+    if level is None:
+        level = pywt.dwtn_max_level(
+            [data.shape[-3], data.shape[-2], data.shape[-1]],
+            pywt.Wavelet("MyWavelet", wavelet),
+        )
+
+    result_lst: List[
+        Union[jnp.ndarray, Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]]
+    ] = []
+    res_lll = data
+    for _ in range(level):
+        if res_lll.ndim == 4:
+            res_lll = jnp.expand_dims(res_lll, 1)
+        res_lll = _fwt_pad3d(res_lll, len(wavelet), mode=mode)
+        res = jax.lax.conv_general_dilated(
+            lhs=res_lll,  # lhs = NCHw image tensor
+            rhs=dec_filt,  # rhs = OIHw conv kernel tensor
+            padding="VALID",
+            window_strides=[2, 2, 2],
+            dimension_numbers=("NCDHW", "OIDHW", "NCDHW"),
+            precision=jax.lax.Precision(precision),
+        )
+        res_lll, res_llh, res_lhl, res_lhh, res_hll, res_hlh, res_hhl, res_hhh = [
+            sr.squeeze(1) for sr in jnp.split(res, 8, 1)
+        ]
+        result_lst.append(
+            {
+                "aad": res_llh,
+                "ada": res_lhl,
+                "add": res_lhh,
+                "daa": res_hll,
+                "dad": res_hlh,
+                "dda": res_hhl,
+                "ddd": res_hhh,
+            }
+        )
+    result_lst.append(res_lll)
+    result_lst.reverse()
+
+    if fold:
+        unfold_list: List[Union[jnp.ndarray, Tuple[jnp.ndarray, ...]]] = []
+        for fres in result_lst:
+            if isinstance(fres, jnp.ndarray):
+                unfold_list.append(_unfold_axes(fres, ds, 3))
+            else:
+                unfold_list.append(
+                    {key: _unfold_axes(fres_el, ds, 3) for key, fres_el in fres.items()}
+                )
+        result_lst = unfold_list  # type: ignore
+
+    return result_lst
+
+
+def waverec3(
+    coeffs: List[Union[jnp.ndarray, Dict[str, jnp.ndarray]]],
+    wavelet: pywt.Wavelet,
+    precision: str = "highest",
+) -> jnp.ndarray:
+    """Compute a two dimensional synthesis wavelet transfrom.
+
+       Use it to reconstruct the original input image from the wavelet coefficients.
+
+    Args:
+        coeffs (list): The input coefficients, typically the output of wavedec3.
+        wavelet (pywt.Wavelet): The named tuple contining the filters used to compute the analysis transform.
+        precision (str): The desired precision, choose "fastest", "high" or "highest".
+            Defaults to "highest".
+
+    Returns:
+        jnp.array: Reconstruction of the original input data array.
+            For example of shape [batch, channels, height, width].
+
+    Example:
+        >>> import pywt
+        >>> import jaxwt as jwt
+        >>> import jax
+        >>> data = jax.random.uniform(jax.random.PRNGKey(42),
+                                      [3, 16, 16, 16])
+        >>> rec = jwt.waverec3(jwt.wavedec3(data, "haar", level=2), "haar")
+        >>> jax.numpy.allclose(data, rec)
+
+    """
+    wavelet = _as_wavelet(wavelet)
+
+    fold = False
+    if _check_if_array(coeffs[0]).ndim > 3:
+        fold = True
+        ds = list(_check_if_array(coeffs[0]).shape)
+        fold_list: List[Union[jnp.ndarray, Dict[str, jnp.ndarray]]] = []
+        for coeff in coeffs:
+            if isinstance(coeff, jnp.ndarray):
+                fold_list.append(_fold_axes(coeff, 3)[0])
+            else:
+                fold_list.append(
+                    {key: _fold_axes(coeff_el, 3)[0] for key, coeff_el in coeff.items()}
+                )
+        coeffs = fold_list  # type: ignore
+
+    _, _, rec_lo, rec_hi = _get_filter_arrays(
+        wavelet, flip=True, dtype=_check_if_array(coeffs[0]).dtype
+    )
+    filt_len = rec_lo.shape[-1]
+    rec_filt = _construct_3d_filt(lo=rec_lo, hi=rec_hi)
+    rec_filt = jnp.transpose(rec_filt, [1, 0, 2, 3, 4])
+
+    res_lll = jnp.expand_dims(_check_if_array(coeffs[0]), 1)
+    for c_pos, coeff_dict in enumerate(coeffs[1:]):
+        res_lll = jnp.concatenate(
+            [
+                res_lll,
+                jnp.expand_dims(coeff_dict["aad"], 1),
+                jnp.expand_dims(coeff_dict["ada"], 1),
+                jnp.expand_dims(coeff_dict["add"], 1),
+                jnp.expand_dims(coeff_dict["daa"], 1),
+                jnp.expand_dims(coeff_dict["dad"], 1),
+                jnp.expand_dims(coeff_dict["dda"], 1),
+                jnp.expand_dims(coeff_dict["ddd"], 1),
+            ],
+            1,
+        )
+        res_lll = jax.lax.conv_transpose(
+            lhs=res_lll,
+            rhs=rec_filt,
+            padding="VALID",
+            strides=[2, 2, 2],
+            dimension_numbers=("NCDHW", "OIDHW", "NCDHW"),
+            precision=jax.lax.Precision(precision),
+        )
+        # remove the padding
+        padl = (2 * filt_len - 3) // 2
+        padr = (2 * filt_len - 3) // 2
+        padt = (2 * filt_len - 3) // 2
+        padb = (2 * filt_len - 3) // 2
+        padfr = (2 * filt_len - 3) // 2
+        padba = (2 * filt_len - 3) // 2
+
+        if c_pos < len(coeffs) - 2:
+            pred_len = res_lll.shape[-1] - (padl + padr)
+            next_len = coeffs[c_pos + 2]["aad"].shape[-1]
+            pred_len2 = res_lll.shape[-2] - (padt + padb)
+            next_len2 = coeffs[c_pos + 2]["aad"].shape[-2]
+            pred_len3 = res_lll.shape[-3] - (padt + padb)
+            next_len3 = coeffs[c_pos + 2]["aad"].shape[-3]
+            if next_len != pred_len:
+                padr += 1
+                pred_len = res_lll.shape[-1] - (padl + padr)
+                assert (
+                    next_len == pred_len
+                ), "padding error, please open an issue on github "
+            if next_len2 != pred_len2:
+                padb += 1
+                pred_len2 = res_lll.shape[-2] - (padt + padb)
+                assert (
+                    next_len2 == pred_len2
+                ), "padding error, please open an issue on github "
+            if next_len3 != pred_len3:
+                padba += 1
+                pred_len3 = res_lll.shape[-3] - (padfr + padba)
+                assert (
+                    next_len3 == pred_len3
+                ), "padding error, please open an issue on github "
+
+        # print('padding', padt, padb, padl, padr)
+        if padt > 0:
+            res_lll = res_lll[..., padt:, :]
+        if padb > 0:
+            res_lll = res_lll[..., :-padb, :]
+        if padl > 0:
+            res_lll = res_lll[..., padl:]
+        if padr > 0:
+            res_lll = res_lll[..., :-padr]
+        if padfr > 0:
+            res_lll = res_lll[..., padfr:, :, :]
+        if padba > 0:
+            res_lll = res_lll[..., :-padba, :, :]
+
+    res_lll = res_lll.squeeze(1)
+
+    if fold:
+        res_lll = _unfold_axes(res_lll, ds, 3)
+    return res_lll
+
+
+def _construct_3d_filt(lo: jnp.ndarray, hi: jnp.ndarray) -> jnp.ndarray:
+    """Construct three-dimensional filters using outer products.
+
+    Args:
+        lo (torch.Tensor): Low-pass input filter.
+        hi (torch.Tensor): High-pass input filter
+
+    Returns:
+        torch.Tensor: Stacked 3d filters of dimension::
+
+        [8, 1, length, height, width].
+
+        The four filters are ordered ll, lh, hl, hh.
+
+    """
+    dim_size = lo.shape[-1]
+    size = [dim_size] * 3
+    lll = jnp.reshape(jnp.outer(lo, jnp.outer(lo, lo)), size)
+    llh = jnp.reshape(jnp.outer(lo, jnp.outer(lo, hi)), size)
+    lhl = jnp.reshape(jnp.outer(lo, jnp.outer(hi, lo)), size)
+    lhh = jnp.reshape(jnp.outer(lo, jnp.outer(hi, hi)), size)
+    hll = jnp.reshape(jnp.outer(hi, jnp.outer(lo, lo)), size)
+    hlh = jnp.reshape(jnp.outer(hi, jnp.outer(lo, hi)), size)
+    hhl = jnp.reshape(jnp.outer(hi, jnp.outer(hi, lo)), size)
+    hhh = jnp.reshape(jnp.outer(hi, jnp.outer(hi, hi)), size)
+    filt = jnp.stack([lll, llh, lhl, lhh, hll, hlh, hhl, hhh], 0)
+    filt = jnp.expand_dims(filt, 1)
+    return filt
+
+
+def _fwt_pad3d(
+    data: jnp.ndarray, filt_len: int, mode: str = "symmetric"
+) -> jnp.ndarray:
+    padr = 0
+    padl = 0
+    padt = 0
+    padb = 0
+    padfr = 0
+    padba = 0
+
+    if filt_len > 2:
+        # we pad half of the total requried padding on each side.
+        padr += (2 * filt_len - 3) // 2
+        padl += (2 * filt_len - 3) // 2
+        padt += (2 * filt_len - 3) // 2
+        padb += (2 * filt_len - 3) // 2
+        padfr += (2 * filt_len - 3) // 2
+        padba += (2 * filt_len - 3) // 2
+
+    # pad to even singal length.
+    if data.shape[-1] % 2 != 0:
+        padr += 1
+    if data.shape[-2] % 2 != 0:
+        padb += 1
+    if data.shape[-3] % 2 != 0:
+        padba += 1
+
+    data = jnp.pad(
+        data, ((0, 0), (0, 0), (padfr, padba), (padt, padb), (padl, padr)), mode
+    )
+    return data

--- a/src/jaxwt/conv_fwt_3d.py
+++ b/src/jaxwt/conv_fwt_3d.py
@@ -1,4 +1,4 @@
-"""Three dimensional transformation support."""
+"""Three-dimensional transformation support."""
 #
 # Created on Fri Aug 4 2023
 # Copyright (c) 2023 Moritz Wolter
@@ -24,26 +24,26 @@ from .utils import (
 
 def wavedec3(
     data: jnp.ndarray,
-    wavelet: pywt.Wavelet,
+    wavelet: Union[pywt.Wavelet, str],
     mode: str = "symmetric",
     level: Optional[int] = None,
     axes: Tuple[int, int, int] = (-3, -2, -1),
     precision: str = "highest",
 ) -> List[Union[jnp.ndarray, Dict[str, jnp.ndarray]]]:
-    """Compute the three dimensional wavelet analysis transform on the last three \
+    """Compute the three-dimensional wavelet analysis transform on the last three \
        dimensions of the input data array.
 
     Args:
         data (jnp.ndarray): Jax array containing the data to be transformed.
-            A possible input shape would be [batch size, channels, hight, width].
-        wavelet (pywt.Wavelet): A namedtouple containing the filters for the transformation.
+            A possible input shape would be [batch size, channels, height, width].
+        wavelet (Union[pywt.Wavelet, str]): A wavelet object or str for the transformation.
         mode (str): The desired padding mode. Choose reflect, symmetric or zero.
             Defaults to symmetric.
         level (int): The max level to be used, if not set as many levels as possible
                                will be used. Defaults to None.
         axes (Tuple[int, int, int]): Compute the transform over these axes instead of the
             last three. Defaults to (-3, -2, -1).
-        precision (str): The desired precision, choose "fastest", "high" or "highest".
+        precision (str): For desired precision, choose "fastest", "high" or "highest".
             Defaults to "highest".
 
     Returns:
@@ -57,7 +57,7 @@ def wavedec3(
 
     Raises:
         ValueError: If the input has less than three dimensions.
-        ValueError: If axes does not have three elements or contains a repetition.
+        ValueError: If the axes tuple does not have three elements or contains a repetition.
 
     Examples:
         >>> import pywt
@@ -144,20 +144,20 @@ def wavedec3(
 
 def waverec3(
     coeffs: List[Union[jnp.ndarray, Dict[str, jnp.ndarray]]],
-    wavelet: pywt.Wavelet,
+    wavelet: Union[pywt.Wavelet, str],
     axes: Tuple[int, int, int] = (-3, -2, -1),
     precision: str = "highest",
 ) -> jnp.ndarray:
-    """Compute a two dimensional synthesis wavelet transfrom.
+    """Compute a three-dimensional synthesis wavelet transform.
 
        Use it to reconstruct the original input image from the wavelet coefficients.
 
     Args:
         coeffs (list): The input coefficients, typically the output of wavedec3.
-        wavelet (pywt.Wavelet): The named tuple contining the filters used to compute the analysis transform.
+        wavelet (Union[pywt.Wavelet, str]): The wavelet we want.
         axes (Tuple[int, int, int]): Transform these axes instead of the
             last three. Defaults to (-3, -2, -1).
-        precision (str): The desired precision, choose "fastest", "high" or "highest".
+        precision (str): For desired precision, choose "fastest", "high" or "highest".
             Defaults to "highest".
 
     Returns:
@@ -165,7 +165,8 @@ def waverec3(
             For example of shape [batch, channels, height, width].
 
     Raises:
-        ValueError: If axes does not have three elements or contains a repetition.
+        ValueError: If the axes list does not have three elements
+            or contains a repetition.
 
     Example:
         >>> import pywt

--- a/src/jaxwt/conv_fwt_3d.py
+++ b/src/jaxwt/conv_fwt_3d.py
@@ -22,8 +22,8 @@ from .utils import (
 def wavedec3(
     data: jnp.ndarray,
     wavelet: pywt.Wavelet,
-    level: Optional[int] = None,
     mode: str = "symmetric",
+    level: Optional[int] = None,
     precision: str = "highest",
 ) -> List[Union[jnp.ndarray, Dict[str, jnp.ndarray]]]:
     """Compute the three dimensional wavelet analysis transform on the last three \

--- a/src/jaxwt/packets.py
+++ b/src/jaxwt/packets.py
@@ -28,7 +28,7 @@ class WaveletPacket(BaseDict):
     def __init__(
         self,
         data: jnp.ndarray,
-        wavelet: pywt.Wavelet,
+        wavelet: Union[pywt.Wavelet, str],
         mode: str = "symmetric",
         max_level: Optional[int] = None,
     ):
@@ -36,7 +36,7 @@ class WaveletPacket(BaseDict):
 
         Args:
             data (jnp.ndarray): The input data array of shape [batch_size, time].
-            wavelet (pywt.Wavelet): The wavelet used for the decomposition.
+            wavelet (Union[pywt.Wavelet, str]): The wavelet used for the decomposition.
             mode (str): The desired padding method. Choose i.e.
                 "reflect", "symmetric" or "zero". Defaults to "symmetric".
 

--- a/src/jaxwt/packets.py
+++ b/src/jaxwt/packets.py
@@ -100,7 +100,9 @@ class WaveletPacket(BaseDict):
     ) -> None:
         self.data[path] = data
         if level < self.max_level:
-            res_lo, res_hi = wavedec(data, self.wavelet, 1, mode=self.mode)
+            res_lo, res_hi = wavedec(
+                data=data, wavelet=self.wavelet, level=1, mode=self.mode
+            )
             self._recursive_dwt(res_lo, level + 1, path + "a")
             self._recursive_dwt(res_hi, level + 1, path + "d")
         else:
@@ -183,7 +185,7 @@ class WaveletPacket2D(BaseDict):
         self.data[path] = data
         if level < self.max_level:
             result_a, (result_h, result_v, result_d) = wavedec2(
-                data, self.wavelet, 1, mode=self.mode
+                data=data, wavelet=self.wavelet, level=1, mode=self.mode
             )
             # assert for type checking
             assert not isinstance(result_a, tuple)

--- a/src/jaxwt/packets.py
+++ b/src/jaxwt/packets.py
@@ -29,7 +29,7 @@ class WaveletPacket(BaseDict):
         self,
         data: jnp.ndarray,
         wavelet: pywt.Wavelet,
-        mode: str = "reflect",
+        mode: str = "symmetric",
         max_level: Optional[int] = None,
     ):
         """Create a wavelet packet decomposition object.
@@ -38,7 +38,7 @@ class WaveletPacket(BaseDict):
             data (jnp.ndarray): The input data array of shape [batch_size, time].
             wavelet (pywt.Wavelet): The wavelet used for the decomposition.
             mode (str): The desired padding method. Choose i.e.
-                "reflect", "symmetric" or "zero". Defaults to "reflect".
+                "reflect", "symmetric" or "zero". Defaults to "symmetric".
 
         Example:
             >>> import pywt
@@ -147,7 +147,7 @@ class WaveletPacket2D(BaseDict):
         self,
         data: jnp.ndarray,
         wavelet: Union[str, pywt.Wavelet],
-        mode: str = "reflect",
+        mode: str = "symmetric",
         max_level: Optional[int] = None,
     ):
         """Create a 2D-wavelet packet decomposition object.
@@ -159,7 +159,7 @@ class WaveletPacket2D(BaseDict):
             data (jnp.ndarray): The input data array of shape [batch_size, height, width].
             wavelet (pywt.Wavelet or str): The wavelet used for the decomposition.
             mode (str): The desired padding method. Choose i.e.
-                "reflect", "symmetric" or "zero". Defaults to "reflect".
+                "reflect", "symmetric" or "zero". Defaults to "symmetric".
             max_level (int, optional): Choose the desired decomposition level.
         """
         self.input_data = data

--- a/src/jaxwt/stationary_transform.py
+++ b/src/jaxwt/stationary_transform.py
@@ -85,7 +85,7 @@ def _conv_transpose_dedilate(
         rec_filt (jnp.ndarray): The reconstruction filter pair
             of shape [1, 2, filter_length].
         dilation (int): The dilation factor.
-        length (int): The signal lenght.
+        length (int): The signal length.
         precision (str): Defaults to "highest".
 
     Returns:
@@ -112,9 +112,20 @@ def _conv_transpose_dedilate(
 
 def iswt(
     coeffs: List[jnp.ndarray],
-    wavelet: pywt.Wavelet,
+    wavelet: Union[pywt.Wavelet, str],
     precision: str = "highest",
 ) -> jnp.ndarray:
+    """Computes an inverse stationary wavelet transform.
+
+    Args:
+        coeffs (List[jnp.ndarray]): The coefficients as computed by the analysis code.
+        wavelet (Union[pywt.Wavelet, str]): The wavelet used by the transform.
+        precision (str, optional): Precision value for lax convolution code.
+            Defaults to "highest".
+
+    Returns:
+        jnp.ndarray: The reconstruction of the original signal.
+    """
     ds = None
     length = coeffs[0].shape[-1]
     if coeffs[0].ndim > 2:

--- a/src/jaxwt/stationary_transform.py
+++ b/src/jaxwt/stationary_transform.py
@@ -1,4 +1,9 @@
 """Code for stationary wavelet transforms."""
+#
+# Created on Fri Aug 04 2023
+# Copyright (c) 2023 Moritz Wolter
+#
+
 from typing import List, Optional, Union
 
 import jax
@@ -23,13 +28,19 @@ def swt(
     """Compute a multilevel 1d stationary wavelet transform.
 
     Args:
-        data (torch.Tensor): The input data of shape [batch_size, time].
+        data (jnp.ndarray): The input data of shape [batch_size, time].
+            The function assumes the last dimension to have a length divisible
+            by two.
         wavelet (Union[Wavelet, str]): The wavelet to use.
         level (Optional[int], optional): The number of levels to compute
 
     Returns:
-        List[torch.Tensor]: Same as wavedec.
-        Equivalent to pywt.swt with trim_approx=True.
+        List[jnp.ndarray]: A list containing the wavelet coefficients.
+            The coefficients are in pywt order:
+            [cA_n, cD_n, cD_n-1, …, cD2, cD1].
+            A denotes approximation and D detail coefficients.
+            The ordering is identical to the ``wavedec`` function.
+            Equivalent to pywt.swt with trim_approx=True.
     """
     wavelet = _as_wavelet(wavelet)
     data, ds = _preprocess_array_dec1d(data)

--- a/src/jaxwt/stationary_transform.py
+++ b/src/jaxwt/stationary_transform.py
@@ -9,7 +9,7 @@ from .conv_fwt import (
     _get_filter_arrays,
     _postprocess_result_list_dec1d,
     _preprocess_array_dec1d,
-    _preprocess_result_list_rec1d
+    _preprocess_result_list_rec1d,
 )
 from .utils import _as_wavelet, _unfold_axes
 

--- a/src/jaxwt/stationary_transform.py
+++ b/src/jaxwt/stationary_transform.py
@@ -29,8 +29,8 @@ def swt(
 
     Args:
         data (jnp.ndarray): The input data of shape [batch_size, time].
-            The function assumes the last dimension to have a length divisible
-            by two.
+            This function assumes a trailing input dimension with
+            a length divisible by two.
         wavelet (Union[Wavelet, str]): The wavelet to use.
         level (Optional[int], optional): The number of levels to compute
 
@@ -41,6 +41,13 @@ def swt(
             A denotes approximation and D detail coefficients.
             The ordering is identical to the ``wavedec`` function.
             Equivalent to pywt.swt with trim_approx=True.
+
+    Example:
+        >>> import jax, jaxwt
+        >>> import jax.numpy as jnp
+        >>> signal = jax.random.randint(
+                jax.random.PRNGKey(42), [1, 10], 0, 9).astype(jnp.float32)
+        >>> jaxwt.swt(signal, "haar", level=2)
     """
     wavelet = _as_wavelet(wavelet)
     data, ds = _preprocess_array_dec1d(data)
@@ -101,6 +108,14 @@ def _conv_transpose_dedilate(
 
     Returns:
         jnp.ndarray: The convolution result.
+
+
+    Example:
+        >>> import jax, jaxwt
+        >>> import jax.numpy as jnp
+        >>> signal = jax.random.randint(
+                jax.random.PRNGKey(42), [1, 10], 0, 9).astype(jnp.float32)
+        >>> jaxwt.iswt(jaxwt.swt(signal, "haar", level=2), "haar")
     """
     recs = []
     to_conv_t_list = [

--- a/src/jaxwt/stationary_transform.py
+++ b/src/jaxwt/stationary_transform.py
@@ -113,14 +113,14 @@ def _conv_transpose_dedilate(
 def iswt(
     coeffs: List[jnp.ndarray],
     wavelet: Union[pywt.Wavelet, str],
-    precision: str = "highest",
+    precision: Optional[str] = "highest",
 ) -> jnp.ndarray:
-    """Computes an inverse stationary wavelet transform.
+    """Compute an inverse stationary wavelet transform.
 
     Args:
         coeffs (List[jnp.ndarray]): The coefficients as computed by the analysis code.
         wavelet (Union[pywt.Wavelet, str]): The wavelet used by the transform.
-        precision (str, optional): Precision value for lax convolution code.
+        precision (Optional[str]): Precision value for lax convolution code.
             Defaults to "highest".
 
     Returns:

--- a/src/jaxwt/utils.py
+++ b/src/jaxwt/utils.py
@@ -80,3 +80,19 @@ def _fold_axes(data: jnp.ndarray, keep_no: int) -> Tuple[jnp.ndarray, List[int]]
 def _unfold_axes(data: jnp.ndarray, ds: List[int], keep_no: int) -> jnp.ndarray:
     """Unfold i.e. [batch*channel, height, widht] into [batch, channel, height, width]."""
     return jnp.reshape(data, ds[:-keep_no] + list(data.shape[-keep_no:]))
+
+
+def _adjust_padding_at_reconstruction(
+    res_size: int, coeff_size: int, pad_end: int, pad_start: int
+) -> Tuple[int, int]:
+    pred_size = res_size - (pad_start + pad_end)
+    next_size = coeff_size
+    if next_size == pred_size:
+        pass
+    elif next_size == pred_size - 1:
+        pad_end += 1
+    else:
+        raise AssertionError(
+            "padding error, please check if dec and rec wavelets are identical."
+        )
+    return pad_end, pad_start

--- a/src/jaxwt/utils.py
+++ b/src/jaxwt/utils.py
@@ -5,6 +5,7 @@ from collections import namedtuple
 from typing import List, Tuple, Union
 
 import jax.numpy as jnp
+import numpy as np
 import pywt
 
 __all__ = ["flatten_2d_coeff_lst"]
@@ -59,3 +60,23 @@ def _as_wavelet(wavelet: Union[Wavelet, str]) -> pywt.Wavelet:
         return pywt.Wavelet(wavelet)
     else:
         return wavelet
+
+
+def _fold_axes(data: jnp.ndarray, keep_no: int) -> Tuple[jnp.ndarray, List[int]]:
+    """Fold unchanged leading dimensions into a single batch dimension.
+
+    Args:
+        data (jnp.ndarray): The input data array.
+        keep_no (int): The number of dimensions to keep.
+
+    Returns:
+        Tuple[jnp.ndarray, List[int]]:
+            The folded result array, and the shape of the original input.
+    """
+    dshape = list(data.shape)
+    return jnp.reshape(data, [np.prod(dshape[:-keep_no])] + dshape[-keep_no:]), dshape
+
+
+def _unfold_axes(data: jnp.ndarray, ds: List[int], keep_no: int) -> jnp.ndarray:
+    """Unfold i.e. [batch*channel, height, widht] into [batch, channel, height, width]."""
+    return jnp.reshape(data, ds[:-keep_no] + list(data.shape[-keep_no:]))

--- a/src/jaxwt/utils.py
+++ b/src/jaxwt/utils.py
@@ -2,7 +2,7 @@
 
 # -*- coding: utf-8 -*-
 from collections import namedtuple
-from typing import List, Tuple, Union
+from typing import Any, List, Tuple, Union
 
 import jax.numpy as jnp
 import numpy as np
@@ -96,3 +96,11 @@ def _adjust_padding_at_reconstruction(
             "padding error, please check if dec and rec wavelets are identical."
         )
     return pad_end, pad_start
+
+
+def _check_if_array(array: Any) -> jnp.ndarray:
+    if not isinstance(array, jnp.ndarray):
+        raise ValueError(
+            "First element of coeffs must be the approximation coefficient tensor."
+        )
+    return array

--- a/src/jaxwt/utils.py
+++ b/src/jaxwt/utils.py
@@ -1,6 +1,7 @@
 """Various utility functions."""
-
-# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2023 Moritz Wolter
+#
 from collections import namedtuple
 from typing import Any, List, Tuple, Union
 

--- a/tests/test_conv_fwt.py
+++ b/tests/test_conv_fwt.py
@@ -91,11 +91,11 @@ def test_batch_fwt_ifwt(wavelet, mode, batch_size, level, dtype: jnp.dtype):
 
 
 @pytest.mark.parametrize("level", [1, 2, 3, None])
-@pytest.mark.parametrize("inshape", [(3, 2, 64), (4, 3, 2, 64)])
-def test_multi_batch_fwt(level, inshape):
+@pytest.mark.parametrize("shape", [(64,), (1, 64), (3, 2, 64), (4, 3, 2, 64)])
+def test_multi_batch_fwt(level, shape):
     """Test 1d conv support for multiple inert batch dimensions."""
     key = random.PRNGKey(42)
-    data = jax.random.normal(key, inshape, jnp.float64)
+    data = jax.random.normal(key, shape, jnp.float64)
 
     jaxwt_coeff = wavedec(data, "haar", level=level)
     pywt_coeff = pywt.wavedec(np.array(data), "haar", level=level)

--- a/tests/test_conv_fwt.py
+++ b/tests/test_conv_fwt.py
@@ -109,7 +109,7 @@ def test_multi_batch_fwt(level, shape):
     assert np.allclose(data, rec)
 
 
-@pytest.mark.parametrize("axis", [-1, 1, 2])
+@pytest.mark.parametrize("axis", [-1, 0, 1, 2])
 def test_axis_arg(axis):
     """Ensure the axis argument works as expected."""
     key = random.PRNGKey(42)

--- a/tests/test_conv_fwt.py
+++ b/tests/test_conv_fwt.py
@@ -72,7 +72,7 @@ def test_fwt_ifwt_lorenz(wavelet, level, mode, tmax):
 
 
 @pytest.mark.parametrize("wavelet", ["db2", "sym4"])
-@pytest.mark.parametrize("mode", ["reflect", "zero"])
+@pytest.mark.parametrize("mode", ["symmetric", "reflect", "zero"])
 @pytest.mark.parametrize("batch_size", [1, 3])
 @pytest.mark.parametrize("level", [2, None])
 @pytest.mark.parametrize("dtype", [jnp.float64, jnp.float32])

--- a/tests/test_conv_fwt.py
+++ b/tests/test_conv_fwt.py
@@ -103,8 +103,24 @@ def test_multi_batch_fwt(level, shape):
     test = []
     for jaxwtc, pywtc in zip(jaxwt_coeff, pywt_coeff):
         test.append(np.allclose(jaxwtc, pywtc))
-
     assert all(test)
 
     rec = waverec(jaxwt_coeff, "haar")
+    assert np.allclose(data, rec)
+
+
+@pytest.mark.parametrize("axis", [-1, 1, 2])
+def test_axis_arg(axis):
+    """Ensure the axis argument works as expected."""
+    key = random.PRNGKey(42)
+    data = jax.random.normal(key, [16, 16, 16], jnp.float64)
+
+    jaxwtcs = wavedec(data, "haar", level=2, axis=axis)
+    pywtcs = pywt.wavedec(data, "haar", level=2, axis=axis)
+    test = []
+    for jaxwtc, pywtc in zip(jaxwtcs, pywtcs):
+        test.append(np.allclose(jaxwtc, pywtc))
+    assert all(test)
+
+    rec = waverec(jaxwtcs, "haar", axis=axis)
     assert np.allclose(data, rec)

--- a/tests/test_conv_fwt.py
+++ b/tests/test_conv_fwt.py
@@ -91,10 +91,11 @@ def test_batch_fwt_ifwt(wavelet, mode, batch_size, level, dtype: jnp.dtype):
 
 
 @pytest.mark.parametrize("level", [1, 2, 3, None])
-def test_multi_batch_fwt(level):
+@pytest.mark.parametrize("inshape", [(3, 2, 64), (4, 3, 2, 64)])
+def test_multi_batch_fwt(level, inshape):
     """Test 1d conv support for multiple inert batch dimensions."""
     key = random.PRNGKey(42)
-    data = jax.random.normal(key, (3, 2, 1, 64), jnp.float64)
+    data = jax.random.normal(key, inshape, jnp.float64)
 
     jaxwt_coeff = wavedec(data, "haar", level=level)
     pywt_coeff = pywt.wavedec(np.array(data), "haar", level=level)

--- a/tests/test_conv_fwt2d.py
+++ b/tests/test_conv_fwt2d.py
@@ -1,4 +1,8 @@
 """2d Convolution fast wavelet transform test code."""
+#
+# Copyright (c) 2023 Moritz Wolter
+#
+
 from typing import List
 
 import jax

--- a/tests/test_conv_fwt2d.py
+++ b/tests/test_conv_fwt2d.py
@@ -15,7 +15,7 @@ config.update("jax_enable_x64", True)
 config.update("jax_platform_name", "cpu")
 
 
-@pytest.mark.parametrize("mode", ["symmetric", "reflect"])
+@pytest.mark.parametrize("mode", ["symmetric", "reflect", "zero"])
 @pytest.mark.parametrize("wavelet", ["haar", "db2", "db3", "sym4"])
 @pytest.mark.parametrize("level", [1, 2, None])
 @pytest.mark.parametrize("size", [(65, 65), (64, 64), (47, 45), (45, 47)])

--- a/tests/test_conv_fwt2d.py
+++ b/tests/test_conv_fwt2d.py
@@ -1,4 +1,7 @@
 """2d Convolution fast wavelet transform test code."""
+from typing import List
+
+import jax
 import jax.numpy as jnp
 import pytest
 import pywt
@@ -18,7 +21,7 @@ config.update("jax_platform_name", "cpu")
 @pytest.mark.parametrize("size", [(65, 65), (64, 64), (47, 45), (45, 47)])
 @pytest.mark.parametrize("dtype", [jnp.float64, jnp.float32])
 def test_conv_2d(wavelet: str, level: int, size: tuple, mode: str, dtype: jnp.dtype):
-    """Run a specific test."""
+    """Runs tests of the two-dimensional fwt code."""
     if dtype == jnp.float32:
         atol = 1e-3
     else:
@@ -38,3 +41,30 @@ def test_conv_2d(wavelet: str, level: int, size: tuple, mode: str, dtype: jnp.dt
     # test invertability
     reconstruction_2d = waverec2(coeff2d, wavelet)[..., : size[0], : size[1]]
     assert jnp.allclose(reconstruction_2d, face, atol=atol)
+
+
+@pytest.mark.parametrize("size", [[5, 4, 64, 64], [4, 3, 2, 32, 32], [1, 1, 1, 16, 16]])
+def test_multidim_input(size: List[int]):
+    """Ensure correct folding of multidimensional inputs."""
+    key = jax.random.PRNGKey(42)
+    data = jax.random.uniform(key, size).astype(jnp.float64)
+
+    jaxwt_coeff = wavedec2(data, "db2", level=3)
+    pywt_coeff = pywt.wavedec2(data, "db2", level=3)
+
+    test_list = []
+    for jaxwtc, pywtc in zip(jaxwt_coeff, pywt_coeff):
+        if isinstance(jaxwtc, jnp.ndarray):
+            test_list.append(jnp.allclose(jaxwtc, pywtc))
+        else:
+            test_list.append(
+                tuple(
+                    jnp.allclose(jaxwtce, pywtce)
+                    for jaxwtce, pywtce in zip(jaxwtc, pywtc)
+                )
+            )
+    assert all(test_list)
+
+    rec = waverec2(jaxwt_coeff, "db2")
+
+    assert jnp.allclose(data, rec)

--- a/tests/test_conv_fwt2d.py
+++ b/tests/test_conv_fwt2d.py
@@ -57,7 +57,7 @@ def test_multidim_input(size: List[int]):
         if isinstance(jaxwtc, jnp.ndarray):
             test_list.append(jnp.allclose(jaxwtc, pywtc))
         else:
-            test_list.append(
+            test_list.extend(
                 tuple(
                     jnp.allclose(jaxwtce, pywtce)
                     for jaxwtce, pywtce in zip(jaxwtc, pywtc)

--- a/tests/test_conv_fwt2d.py
+++ b/tests/test_conv_fwt2d.py
@@ -47,15 +47,7 @@ def test_conv_2d(wavelet: str, level: int, size: tuple, mode: str, dtype: jnp.dt
     assert jnp.allclose(reconstruction_2d, face, atol=atol)
 
 
-@pytest.mark.parametrize("size", [[5, 4, 64, 64], [4, 3, 2, 32, 32], [1, 1, 1, 16, 16]])
-def test_multidim_input(size: List[int]):
-    """Ensure correct folding of multidimensional inputs."""
-    key = jax.random.PRNGKey(42)
-    data = jax.random.uniform(key, size).astype(jnp.float64)
-
-    jaxwt_coeff = wavedec2(data, "db2", level=3)
-    pywt_coeff = pywt.wavedec2(data, "db2", level=3)
-
+def _compare_coeffs(jaxwt_coeff, pywt_coeff):
     test_list = []
     for jaxwtc, pywtc in zip(jaxwt_coeff, pywt_coeff):
         if isinstance(jaxwtc, jnp.ndarray):
@@ -67,8 +59,48 @@ def test_multidim_input(size: List[int]):
                     for jaxwtce, pywtce in zip(jaxwtc, pywtc)
                 )
             )
+    return test_list
+
+
+@pytest.mark.parametrize("size", [[5, 4, 64, 64], [4, 3, 2, 32, 32], [1, 1, 1, 16, 16]])
+def test_multidim_input(size: List[int]):
+    """Ensure correct folding of multidimensional inputs."""
+    key = jax.random.PRNGKey(42)
+    data = jax.random.uniform(key, size).astype(jnp.float64)
+
+    jaxwt_coeff = wavedec2(data, "db2", level=3)
+    pywt_coeff = pywt.wavedec2(data, "db2", level=3)
+
+    test_list = _compare_coeffs(jaxwt_coeff, pywt_coeff)
+    assert all(test_list)
+    rec = waverec2(jaxwt_coeff, "db2")
+    assert jnp.allclose(data, rec)
+
+
+@pytest.mark.parametrize("axes", [(-2, -1), (-1, -2), (-3, -2), (0, 1), (1, 0)])
+def test_axis_argument(axes):
+    """Ensure the axes argument works as expected."""
+    key = jax.random.PRNGKey(42)
+    data = jax.random.uniform(key, [32, 32, 32, 32]).astype(jnp.float64)
+
+    jaxwt_coeff = wavedec2(data, "db2", level=3, axes=axes)
+    pywt_coeff = pywt.wavedec2(data, "db2", level=3, axes=axes)
+    test_list = _compare_coeffs(jaxwt_coeff, pywt_coeff)
     assert all(test_list)
 
-    rec = waverec2(jaxwt_coeff, "db2")
-
+    rec = waverec2(jaxwt_coeff, "db2", axes=axes)
     assert jnp.allclose(data, rec)
+
+
+def test_axis_error_axes_count():
+    """Check the error for too many axes."""
+    with pytest.raises(ValueError):
+        data = jax.random.uniform(jax.random.PRNGKey(42), [32, 32, 32, 32])
+        wavedec2(data, "haar", 1, axes=(1, 2, 3))
+
+
+def test_axis_error_axes_rep():
+    """Check the error for axes repetition."""
+    with pytest.raises(ValueError):
+        data = jax.random.uniform(jax.random.PRNGKey(42), [32, 32, 32, 32])
+        wavedec2(data, "haar", 1, axes=(2, 2))

--- a/tests/test_conv_fwt3d.py
+++ b/tests/test_conv_fwt3d.py
@@ -1,0 +1,43 @@
+from typing import List
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import pywt
+from jax.config import config
+
+from src.jaxwt.conv_fwt_3d import wavedec3, waverec3
+
+config.update("jax_enable_x64", True)
+config.update("jax_platform_name", "cpu")
+
+
+@pytest.mark.parametrize(
+    "size", [[5, 32, 32, 32], [4, 3, 32, 32, 32], [1, 1, 1, 32, 32, 32]]
+)
+@pytest.mark.parametrize("level", [1, 2, None])
+@pytest.mark.parametrize("axes", [[-3, -2, -1]])
+def test_multidim_input(size: List[int], axes: List[int], level: int):
+    """Ensure correct folding of multidimensional inputs."""
+    key = jax.random.PRNGKey(42)
+    data = jax.random.uniform(key, size).astype(jnp.float64)
+
+    jaxwt_coeff = wavedec3(data, "db2", level=level)
+    pywt_coeff = pywt.wavedecn(data, "db2", level=level, axes=axes)
+
+    test_list = []
+    for jaxwtc, pywtc in zip(jaxwt_coeff, pywt_coeff):
+        if isinstance(jaxwtc, jnp.ndarray):
+            test_list.append(jnp.allclose(jaxwtc, pywtc))
+        else:
+            test_list.extend(
+                tuple(
+                    jnp.allclose(jaxwtc[key], pywtce) for key, pywtce in jaxwtc.items()
+                )
+            )
+    assert all(test_list)
+
+    rec = waverec3(jaxwt_coeff, "db2")
+
+    assert jnp.allclose(data, rec)

--- a/tests/test_conv_fwt3d.py
+++ b/tests/test_conv_fwt3d.py
@@ -1,4 +1,8 @@
 """Test 3d transform support."""
+#
+# Created on Fri Aug 04 2023
+# Copyright (c) 2023 Moritz Wolter
+#
 
 from typing import List
 
@@ -21,7 +25,9 @@ config.update("jax_platform_name", "cpu")
 @pytest.mark.parametrize("axes", [[-3, -2, -1]])
 @pytest.mark.parametrize("wavelet", ["haar", "sym3", "db4"])
 @pytest.mark.parametrize("mode", ["zero", "symmetric", "reflect"])
-def test_multidim_input(size: List[int], axes: List[int], level: int, wavelet: str, mode: str):
+def test_multidim_input(
+    size: List[int], axes: List[int], level: int, wavelet: str, mode: str
+):
     """Ensure correct folding of multidimensional inputs."""
     key = jax.random.PRNGKey(42)
     data = jax.random.uniform(key, size).astype(jnp.float64)

--- a/tests/test_conv_fwt3d.py
+++ b/tests/test_conv_fwt3d.py
@@ -20,13 +20,14 @@ config.update("jax_platform_name", "cpu")
 @pytest.mark.parametrize("level", [1, 2, None])
 @pytest.mark.parametrize("axes", [[-3, -2, -1]])
 @pytest.mark.parametrize("wavelet", ["haar", "sym3", "db4"])
-def test_multidim_input(size: List[int], axes: List[int], level: int, wavelet: str):
+@pytest.mark.parametrize("mode", ["zero", "symmetric", "reflect"])
+def test_multidim_input(size: List[int], axes: List[int], level: int, wavelet: str, mode: str):
     """Ensure correct folding of multidimensional inputs."""
     key = jax.random.PRNGKey(42)
     data = jax.random.uniform(key, size).astype(jnp.float64)
 
-    jaxwt_coeff = wavedec3(data, wavelet, level=level)
-    pywt_coeff = pywt.wavedecn(data, wavelet, level=level, axes=axes)
+    jaxwt_coeff = wavedec3(data, wavelet, level=level, mode=mode)
+    pywt_coeff = pywt.wavedecn(data, wavelet, level=level, axes=axes, mode=mode)
 
     test_list = []
     for jaxwtc, pywtc in zip(jaxwt_coeff, pywt_coeff):

--- a/tests/test_conv_fwt3d.py
+++ b/tests/test_conv_fwt3d.py
@@ -1,8 +1,9 @@
+"""Test 3d transform support."""
+
 from typing import List
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 import pytest
 import pywt
 from jax.config import config
@@ -18,13 +19,14 @@ config.update("jax_platform_name", "cpu")
 )
 @pytest.mark.parametrize("level", [1, 2, None])
 @pytest.mark.parametrize("axes", [[-3, -2, -1]])
-def test_multidim_input(size: List[int], axes: List[int], level: int):
+@pytest.mark.parametrize("wavelet", ["haar", "sym3", "db4"])
+def test_multidim_input(size: List[int], axes: List[int], level: int, wavelet: str):
     """Ensure correct folding of multidimensional inputs."""
     key = jax.random.PRNGKey(42)
     data = jax.random.uniform(key, size).astype(jnp.float64)
 
-    jaxwt_coeff = wavedec3(data, "db2", level=level)
-    pywt_coeff = pywt.wavedecn(data, "db2", level=level, axes=axes)
+    jaxwt_coeff = wavedec3(data, wavelet, level=level)
+    pywt_coeff = pywt.wavedecn(data, wavelet, level=level, axes=axes)
 
     test_list = []
     for jaxwtc, pywtc in zip(jaxwt_coeff, pywt_coeff):
@@ -38,6 +40,6 @@ def test_multidim_input(size: List[int], axes: List[int], level: int):
             )
     assert all(test_list)
 
-    rec = waverec3(jaxwt_coeff, "db2")
+    rec = waverec3(jaxwt_coeff, wavelet)
 
     assert jnp.allclose(data, rec)

--- a/tests/test_conv_fwt3d.py
+++ b/tests/test_conv_fwt3d.py
@@ -18,23 +18,7 @@ config.update("jax_enable_x64", True)
 config.update("jax_platform_name", "cpu")
 
 
-@pytest.mark.parametrize(
-    "size", [[5, 32, 32, 32], [4, 3, 32, 32, 32], [1, 1, 1, 32, 32, 32]]
-)
-@pytest.mark.parametrize("level", [1, 2, None])
-@pytest.mark.parametrize("axes", [[-3, -2, -1]])
-@pytest.mark.parametrize("wavelet", ["haar", "sym3", "db4"])
-@pytest.mark.parametrize("mode", ["zero", "symmetric", "reflect"])
-def test_multidim_input(
-    size: List[int], axes: List[int], level: int, wavelet: str, mode: str
-):
-    """Ensure correct folding of multidimensional inputs."""
-    key = jax.random.PRNGKey(42)
-    data = jax.random.uniform(key, size).astype(jnp.float64)
-
-    jaxwt_coeff = wavedec3(data, wavelet, level=level, mode=mode)
-    pywt_coeff = pywt.wavedecn(data, wavelet, level=level, axes=axes, mode=mode)
-
+def _compare_coeffs(jaxwt_coeff, pywt_coeff):
     test_list = []
     for jaxwtc, pywtc in zip(jaxwt_coeff, pywt_coeff):
         if isinstance(jaxwtc, jnp.ndarray):
@@ -45,8 +29,60 @@ def test_multidim_input(
                     jnp.allclose(jaxwtc[key], pywtce) for key, pywtce in jaxwtc.items()
                 )
             )
+    return test_list
+
+
+@pytest.mark.parametrize(
+    "size", [[5, 32, 32, 32], [4, 3, 32, 32, 32], [1, 1, 1, 32, 32, 32]]
+)
+@pytest.mark.parametrize("level", [1, 2, None])
+@pytest.mark.parametrize("wavelet", ["haar", "sym3", "db4"])
+@pytest.mark.parametrize("mode", ["zero", "symmetric", "reflect"])
+def test_multidim_input(size: List[int], level: int, wavelet: str, mode: str):
+    """Ensure correct folding of multidimensional inputs."""
+    key = jax.random.PRNGKey(42)
+    data = jax.random.uniform(key, size).astype(jnp.float64)
+
+    jaxwt_coeff = wavedec3(data, wavelet, level=level, mode=mode)
+    pywt_coeff = pywt.wavedecn(data, wavelet, level=level, mode=mode, axes=[-3, -2, -1])
+    test_list = _compare_coeffs(jaxwt_coeff, pywt_coeff)
     assert all(test_list)
 
     rec = waverec3(jaxwt_coeff, wavelet)
 
     assert jnp.allclose(data, rec)
+
+
+@pytest.mark.parametrize("axes", [[0, 2, 1], [-3, -2, -1]])
+def test_axes_arg(axes):
+    """Test axes argument support."""
+    key = jax.random.PRNGKey(41)
+    data = jax.random.uniform(key, [32, 32, 32, 32, 32]).astype(jnp.float64)
+    jaxwt_coeff = wavedec3(data, "db3", level=2, axes=axes)
+    pywt_coeff = pywt.wavedecn(data, "db3", level=2, axes=axes)
+    test_list = _compare_coeffs(jaxwt_coeff, pywt_coeff)
+    assert all(test_list)
+
+    rec = waverec3(jaxwt_coeff, "db3", axes=axes)
+    assert jnp.allclose(data, rec)
+
+
+def test_axis_error_axes_count():
+    """Check the error for too many axes."""
+    with pytest.raises(ValueError):
+        data = jax.random.uniform(jax.random.PRNGKey(42), [32, 32, 32, 32])
+        wavedec3(data, "haar", 1, axes=(1, 2, 3, 4))
+
+
+def test_axis_error_axes_rep():
+    """Check the error for axes repetition."""
+    with pytest.raises(ValueError):
+        data = jax.random.uniform(jax.random.PRNGKey(42), [32, 32, 32, 32])
+        wavedec3(data, "haar", 1, axes=(1, 2, 2))
+
+
+def test_broken_input():
+    """Check the error for too many axes."""
+    with pytest.raises(ValueError):
+        data = jax.random.uniform(jax.random.PRNGKey(42), [32, 32])
+        wavedec3(data, "haar", 1)

--- a/tests/test_cwt.py
+++ b/tests/test_cwt.py
@@ -1,4 +1,7 @@
 """Test the continuous transformation code."""
+#
+# Copyright (c) 2023 Moritz Wolter
+#
 from typing import Union
 
 import jax.numpy as jnp

--- a/tests/test_cwt.py
+++ b/tests/test_cwt.py
@@ -5,7 +5,10 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 import pywt
+from jax.config import config
 from scipy import signal
+
+config.update("jax_enable_x64", True)
 
 from src.jaxwt.continuous_transform import cwt
 
@@ -39,7 +42,7 @@ def test_cwt(
 ) -> None:
     """Test the cwt implementation for various wavelets."""
     t = np.linspace(-1, 1, samples, endpoint=False)
-    sig = signal.chirp(t, f0=1, f1=50, t1=10, method="linear")
+    sig = signal.chirp(t, f0=1, f1=50, t1=10, method="linear").astype(np.float64)
     cwtmatr, freqs = pywt.cwt(data=sig, scales=scales, wavelet=wavelet)
     cwtmatr_jax, freqs_jax = cwt(jnp.array(sig), jnp.array(scales), wavelet)
     assert jnp.allclose(cwtmatr_jax, cwtmatr)

--- a/tests/test_jit.py
+++ b/tests/test_jit.py
@@ -1,4 +1,7 @@
 """Test jit compilation."""
+#
+# Copyright (c) 2023 Moritz Wolter
+#
 from collections import namedtuple
 
 import jax

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -65,7 +65,9 @@ def test_inverse_packets_1d(input_shape, wavelet, level, mode, base_key):
     assert jnp.allclose(wp[""].data, jwp[""][:, : input_shape[-1]])
 
 
-@pytest.mark.parametrize("input_shape", ((2, 32, 32), (3, 33, 33), (1, 32, 33)))
+@pytest.mark.parametrize(
+    "input_shape", ((2, 32, 32), (3, 33, 33), (1, 32, 33), (1, 2, 32, 32))
+)
 @pytest.mark.parametrize("wavelet", ("haar", "db2"))
 @pytest.mark.parametrize("level", (2, 3))
 @pytest.mark.parametrize("mode", ("reflect", "symmetric", "zero"))

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -66,7 +66,7 @@ def test_inverse_packets_1d(input_shape, wavelet, level, mode, base_key):
 
 
 @pytest.mark.parametrize(
-    "input_shape", ((2, 32, 32), (3, 33, 33), (1, 32, 33), (1, 2, 32, 32))
+    "input_shape", ((2, 32, 32), (3, 33, 33), (1, 32, 33), (3, 2, 32, 32))
 )
 @pytest.mark.parametrize("wavelet", ("haar", "db2"))
 @pytest.mark.parametrize("level", (2, 3))

--- a/tests/test_swt.py
+++ b/tests/test_swt.py
@@ -36,6 +36,22 @@ def test_swt_1d(level, size, wavelet):
     assert jnp.allclose(rec, signal)
 
 
+@pytest.mark.parametrize("axis", [-1, 0, 1, 2])
+def test_axis_arg(axis):
+    """Test swt axis argument support."""
+    key = jax.random.PRNGKey(41)
+    signal = jax.random.randint(key, [32, 32, 32], 0, 9).astype(jnp.float64)
+    jaxwt_coeff = swt(signal, "haar", level=2, axis=axis)
+    pywt_coeff = pywt.swt(signal, "haar", 2, trim_approx=True, norm=False, axis=axis)
+    test_list = []
+    for a, b in zip(jaxwt_coeff, pywt_coeff):
+        test_list.extend([jnp.allclose(ael, bel) for ael, bel in zip(a, b)])
+    assert all(test_list)
+
+    rec = iswt(jaxwt_coeff, "haar", axis=axis)
+    assert jnp.allclose(rec, signal)
+
+
 @pytest.mark.parametrize("wavelet_str", ["db1", "db2", "db3", "sym4"])
 def test_inverse_dilation(wavelet_str):
     """Test transposed dilated convolutions."""

--- a/tests/test_swt.py
+++ b/tests/test_swt.py
@@ -6,8 +6,8 @@ import pytest
 import pywt
 from jax.config import config
 
-from src.jaxwt.stationary_transform import _conv_transpose_dedilate, iswt, swt
 from src.jaxwt.conv_fwt import _get_filter_arrays
+from src.jaxwt.stationary_transform import _conv_transpose_dedilate, iswt, swt
 from src.jaxwt.utils import _as_wavelet
 
 config.update("jax_enable_x64", True)

--- a/tests/test_swt.py
+++ b/tests/test_swt.py
@@ -25,14 +25,14 @@ def test_swt_1d(level, size, wavelet):
     """Test the 1d swt."""
     key = jax.random.PRNGKey(42)
     signal = jax.random.randint(key, size, 0, 9).astype(jnp.float64)
-    ptwt_coeff = swt(signal, wavelet, level=level)
+    jaxwt_coeff = swt(signal, wavelet, level=level)
     pywt_coeff = pywt.swt(signal, wavelet, level, trim_approx=True, norm=False)
     test_list = []
-    for a, b in zip(ptwt_coeff, pywt_coeff):
+    for a, b in zip(jaxwt_coeff, pywt_coeff):
         test_list.extend([jnp.allclose(ael, bel) for ael, bel in zip(a, b)])
     assert all(test_list)
 
-    rec = iswt(ptwt_coeff, wavelet)
+    rec = iswt(jaxwt_coeff, wavelet)
     assert jnp.allclose(rec, signal)
 
 

--- a/tests/test_swt.py
+++ b/tests/test_swt.py
@@ -1,0 +1,89 @@
+"""Test the stationary wavelet transformation code."""
+
+import jax
+import jax.numpy as jnp
+import pytest
+import pywt
+from jax.config import config
+
+from src.jaxwt._stationary_transform import _swt  # _iswt
+from src.jaxwt.conv_fwt import _get_filter_arrays
+from src.jaxwt.utils import _as_wavelet
+
+config.update("jax_enable_x64", True)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("size", [32])
+@pytest.mark.parametrize(
+    "wavelet", ["db1", "db2", "db3"]
+)  # TODO: explore lonnger wavelets.
+@pytest.mark.parametrize("level", [1, 2, None])
+def test_swt_1d(level, size, wavelet):
+    """Test the 1d swt."""
+    signal = jnp.expand_dims(jnp.arange(size).astype(jnp.float64), 0)
+    ptwt_coeff = _swt(signal, wavelet, level=level)
+    pywt_coeff = pywt.swt(signal, wavelet, level, trim_approx=True, norm=False)
+    test_list = []
+    for a, b in zip(ptwt_coeff, pywt_coeff):
+        test_list.extend([jnp.allclose(ael, bel) for ael, bel in zip(a, b)])
+    assert all(test_list)
+
+    # rec = _iswt(ptwt_coeff, wavelet)
+    # assert jnp.allclose(rec, signal)
+    # pass
+
+
+@pytest.mark.parametrize("wavelet_str", ["db1", "db2", "db3"])
+def test_inverse_dilation(wavelet_str):
+    """Test transposed dilated convolutions."""
+    precision = "highest"
+    level = 2
+    dilation = 2**level
+    length = 32
+    print(wavelet_str, dilation)
+
+    wavelet = _as_wavelet(wavelet_str)
+    data = jnp.expand_dims(jnp.arange(length).astype(jnp.float64), (0, 1))
+
+    dec_lo, dec_hi, _, _ = _get_filter_arrays(wavelet, flip=True, dtype=data.dtype)
+    filt_len = dec_lo.shape[-1]
+    filt = jnp.stack([dec_lo, dec_hi], 0)
+
+    padl, padr = dilation * (filt_len // 2 - 1), dilation * (filt_len // 2)
+    datap = jnp.pad(data, [(0, 0)] * (data.ndim - 1) + [(padl, padr)], mode="wrap")
+    conv = jax.lax.conv_general_dilated(
+        lhs=datap,  # lhs = NCH image tensor
+        rhs=filt,  # rhs = OIH conv kernel tensor
+        padding=[(0, 0)],
+        window_strides=[1],
+        rhs_dilation=[dilation],
+        dimension_numbers=("NCT", "OIT", "NCT"),
+        precision=jax.lax.Precision(precision),
+    )
+
+    # unlike pytorch lax's transpose conv requires filter flips.
+    _, _, rec_lo, rec_hi = _get_filter_arrays(wavelet, flip=True, dtype=data.dtype)
+    filt_len = rec_lo.shape[-1]
+    rec_filt = jnp.stack([rec_lo, rec_hi], 1)
+
+    padl, padr = dilation * (filt_len // 2), dilation * (filt_len // 2 - 1)
+    conv = jnp.pad(conv, [(0, 0)] * (data.ndim - 1) + [(padl, padr)], mode="wrap")
+
+    recs = []
+    for fl in range(length):
+        to_conv_t = conv[..., fl : (fl + dilation * filt_len) : dilation]
+        rec = jax.lax.conv_transpose(
+            lhs=to_conv_t,
+            rhs=rec_filt,
+            padding=[(0, 0)],
+            strides=[1],
+            dimension_numbers=("NCH", "OIH", "NCH"),
+            precision=jax.lax.Precision(precision),
+        )
+        recs.append(rec / 2.0)
+    print(" ")
+    rec = jnp.concatenate(recs, -1)
+    print(rec)
+
+    assert jnp.allclose(rec, data)

--- a/tests/test_swt.py
+++ b/tests/test_swt.py
@@ -6,7 +6,7 @@ import pytest
 import pywt
 from jax.config import config
 
-from src.jaxwt._stationary_transform import _conv_transpose_dedilate, _iswt, _swt
+from src.jaxwt.stationary_transform import _conv_transpose_dedilate, iswt, swt
 from src.jaxwt.conv_fwt import _get_filter_arrays
 from src.jaxwt.utils import _as_wavelet
 
@@ -14,20 +14,21 @@ config.update("jax_enable_x64", True)
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("size", [32])
+@pytest.mark.parametrize("size", [[1, 32], [3, 2, 32], [3, 2, 1, 32]])
 @pytest.mark.parametrize("wavelet", ["db1", "db2", "db3", "sym4"])
-@pytest.mark.parametrize("level", [1, 2])
+@pytest.mark.parametrize("level", [1, 2, None])
 def test_swt_1d(level, size, wavelet):
     """Test the 1d swt."""
-    signal = jnp.expand_dims(jnp.arange(size).astype(jnp.float64), 0)
-    ptwt_coeff = _swt(signal, wavelet, level=level)
+    key = jax.random.PRNGKey(42)
+    signal = jax.random.randint(key, size, 0, 9).astype(jnp.float64)
+    ptwt_coeff = swt(signal, wavelet, level=level)
     pywt_coeff = pywt.swt(signal, wavelet, level, trim_approx=True, norm=False)
     test_list = []
     for a, b in zip(ptwt_coeff, pywt_coeff):
         test_list.extend([jnp.allclose(ael, bel) for ael, bel in zip(a, b)])
     assert all(test_list)
 
-    rec = _iswt(ptwt_coeff, wavelet)
+    rec = iswt(ptwt_coeff, wavelet)
     assert jnp.allclose(rec, signal)
 
 

--- a/tests/test_swt.py
+++ b/tests/test_swt.py
@@ -1,4 +1,8 @@
 """Test the stationary wavelet transformation code."""
+#
+# Created on Fri Aug 04 2023
+# Copyright (c) 2023 Moritz Wolter
+#
 
 import jax
 import jax.numpy as jnp

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,21 @@
+"""Test utility code."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax import random
+
+from src.jaxwt.utils import _fold_axes, _unfold_axes
+
+
+@pytest.mark.parametrize("keep_no", [1, 2, 3])
+def test_fold(keep_no):
+    """Try the folding functions."""
+    key = random.PRNGKey(42)
+    data = jax.random.normal(key, (4, 3, 2, 5), jnp.float64)
+
+    folded, ds = _fold_axes(data, keep_no)
+    restored = _unfold_axes(folded, ds, keep_no)
+
+    assert np.allclose(restored, data)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,7 @@
 """Test utility code."""
+#
+# Copyright (c) 2023 Moritz Wolter
+#
 
 import jax
 import jax.numpy as jnp


### PR DESCRIPTION
What's new:
   - now, input arrays can have any dimension. By default, the last dimensions are transformed.
     In the 1D case, the last dimension is transformed.
   - `wavedec3` and `waverec3` allow three-dimensional analysis and synthesis transforms.
   - `swt` and `iswt` implement 1d-stationary wavelet transforms.
   - many transforms now support `pywt`-style axis arguments.

Breaking changes:
   - for `pywt` compatibility, `symmetric` padding is now the default.
   - for `pywt` compatibility argument order is now always `data, wavelet, mode, level, axis`.